### PR TITLE
Update `size` to `linewidth` in `geom_line()`

### DIFF
--- a/slides/07-slides.Rmd
+++ b/slides/07-slides.Rmd
@@ -939,7 +939,7 @@ ggplot(predicted_mpg,
                     (1.96 * .se.fit)),
               fill = "#5601A4", 
               alpha = 0.5) +
-  geom_line(size = 1, color = "#5601A4")
+  geom_line(linewidth = 1, color = "#5601A4")
 ```
 ]
 


### PR DESCRIPTION
This pull request updates `size` argument to `linewidth` for a line-based geom as introduced in ggplot 3.4.0 (<https://www.tidyverse.org/blog/2022/08/ggplot2-3-4-0-size-to-linewidth/>)

Thank you for the great documents!